### PR TITLE
Parse escapes in quoted strings

### DIFF
--- a/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
@@ -421,11 +421,11 @@ public final class ProtoSchemaParser {
           case 't': c = '\t'; break;
           case 'v': c = 0xb; break;
           case 'x':case 'X':
-            c = readHexEscape();
+            c = readNumericEscape(16, 2);
             break;
           case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':
             --pos;
-            c = readOctalEscape();
+            c = readNumericEscape(8, 3);
             break;
           default:
             // use char as-is
@@ -439,35 +439,26 @@ public final class ProtoSchemaParser {
     throw unexpected("unterminated string");
   }
 
-  private char readOctalEscape() {
-    int start = pos;
-    String digits = "";
-    while (pos < data.length && pos < start + 3) {
-      if (!isOctalDigit(data[pos])) break;
-      digits += data[pos++];
+  private char readNumericEscape(int radix, int len) {
+    int value = -1;
+    for (int endPos = Math.min(pos + len, data.length); pos < endPos; pos++) {
+      int digit = hexDigit(data[pos]);
+      if (digit == -1 || digit >= radix) break;
+      if (value < 0) {
+        value = digit;
+      } else {
+        value = value * radix + digit;
+      }
     }
-    return (char) Integer.parseInt(digits, 8);
+    if (value < 0) throw unexpected("expected a digit after \\x or \\X");
+    return (char) value;
   }
 
-  private char readHexEscape() {
-    int start = pos;
-    String digits = "";
-    while (pos < data.length && pos < start + 2) {
-      if (!isHexDigit(data[pos])) break;
-      digits += data[pos++];
-    }
-    if (digits.isEmpty()) {
-      throw unexpected("expected a hex digit after \\x or \\X");
-    }
-    return (char) Integer.parseInt(digits, 16);
-  }
-
-  private boolean isOctalDigit(char c) {
-    return c >= '0' && c <= '7';
-  }
-
-  private boolean isHexDigit(char c) {
-    return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+  private int hexDigit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    else if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    else return -1;
   }
 
   /** Reads a (paren-wrapped), [square-wrapped] or naked symbol name. */


### PR DESCRIPTION
protoc allows \", \, \a, \b, \f, \n, \r, \t, \v, \[xX][0-9a-fA-F]{1,2}, and \[0-7]{1,3} in string literals
