### PR TITLE
Promote inconsistent object model constructors to public.

### DIFF
--- a/src/main/java/com/squareup/protoparser/EnumType.java
+++ b/src/main/java/com/squareup/protoparser/EnumType.java
@@ -12,7 +12,7 @@ public final class EnumType implements Type {
   private final String documentation;
   private final List<Value> values;
 
-  EnumType(String name, String fqname, String documentation, List<Value> values) {
+  public EnumType(String name, String fqname, String documentation, List<Value> values) {
     if (name == null) throw new NullPointerException("name");
     if (fqname == null) throw new NullPointerException("fqname");
     if (documentation == null) throw new NullPointerException("documentation");
@@ -73,7 +73,7 @@ public final class EnumType implements Type {
     private final String documentation;
     private final List<Option> options;
 
-    Value(String name, int tag, String documentation, List<Option> options) {
+    public Value(String name, int tag, String documentation, List<Option> options) {
       if (name == null) throw new NullPointerException("name");
       if (documentation == null) throw new NullPointerException("documentation");
       if (options == null) throw new NullPointerException("options");

--- a/src/main/java/com/squareup/protoparser/MessageType.java
+++ b/src/main/java/com/squareup/protoparser/MessageType.java
@@ -17,7 +17,7 @@ public final class MessageType implements Type {
   private final List<Extensions> extensions;
   private final List<Option> options;
 
-  MessageType(String name, String fqname, String documentation, List<Field> fields,
+  public MessageType(String name, String fqname, String documentation, List<Field> fields,
       List<Type> nestedTypes, List<Extensions> extensions, List<Option> options) {
     if (name == null) throw new NullPointerException("name");
     if (fqname == null) throw new NullPointerException("fqname");
@@ -106,7 +106,7 @@ public final class MessageType implements Type {
     private final List<Option> options;
     private final String documentation;
 
-    Field(Label label, String type, String name, int tag, String documentation,
+    public Field(Label label, String type, String name, int tag, String documentation,
         List<Option> options) {
       if (label == null) throw new NullPointerException("label");
       if (type == null) throw new NullPointerException("type");

--- a/src/main/java/com/squareup/protoparser/Service.java
+++ b/src/main/java/com/squareup/protoparser/Service.java
@@ -13,7 +13,7 @@ public final class Service {
   private final String documentation;
   private final List<Method> methods;
 
-  Service(String name, String fqname, String documentation, List<Method> methods) {
+  public Service(String name, String fqname, String documentation, List<Method> methods) {
     if (name == null) throw new NullPointerException("name");
     if (fqname == null) throw new NullPointerException("fqname");
     if (documentation == null) throw new NullPointerException("documentation");


### PR DESCRIPTION
Prior to this only a subset of the constructors were public which dramatically limited their reuse.

@swankjesse @danrice-square 
