### PR TITLE
Standardize options as a list.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup</groupId>
   <artifactId>protoparser</artifactId>
-  <version>2.3.6-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <name>ProtoParser</name>
   <description>Basic parser for protocol buffer schema declarations.</description>

--- a/src/main/java/com/squareup/protoparser/MessageType.java
+++ b/src/main/java/com/squareup/protoparser/MessageType.java
@@ -2,11 +2,8 @@
 package com.squareup.protoparser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public final class MessageType implements Type {
   private final String name;
@@ -153,46 +150,6 @@ public final class MessageType implements Type {
 
     public List<Option> getOptions() {
       return options;
-    }
-
-    // Retain for compatibility
-    public Map<String, Object> getExtensions() {
-      return optionsToMap(options);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> optionsToMap(List<Option> options) {
-      Map<String, Object> map = new LinkedHashMap<String, Object>();
-      for (Option option : options) {
-        String name = option.getName();
-        Object value = option.getValue();
-
-        if (value instanceof String || value instanceof List) {
-          map.put(name, value);
-        } else if (value instanceof Option) {
-          Map<String, Object> newMap = optionsToMap(Arrays.asList(((Option) value)));
-
-          Object oldValue = map.get(name);
-          if (oldValue instanceof Map) {
-            Map<String, Object> oldMap = (Map<String, Object>) oldValue;
-            for (Map.Entry<String, Object> entry : newMap.entrySet()) {
-              oldMap.put(entry.getKey(), entry.getValue());
-            }
-          } else {
-            map.put(name, newMap);
-          }
-        } else if (value instanceof Map) {
-          Object oldValue = map.get(name);
-          if (oldValue instanceof Map) {
-            ((Map<String, Object>) oldValue).putAll((Map<String, Object>) value);
-          } else {
-            map.put(name, value);
-          }
-        } else {
-          throw new AssertionError("Option value must be String, List, or Map<String, ?>");
-        }
-      }
-      return map;
     }
 
     public String getDocumentation() {

--- a/src/main/java/com/squareup/protoparser/Option.java
+++ b/src/main/java/com/squareup/protoparser/Option.java
@@ -1,7 +1,48 @@
 // Copyright 2013 Square, Inc.
 package com.squareup.protoparser;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 public final class Option {
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> optionsAsMap(List<Option> options) {
+    Map<String, Object> map = new LinkedHashMap<String, Object>();
+    for (Option option : options) {
+      String name = option.getName();
+      Object value = option.getValue();
+
+      if (value instanceof String || value instanceof List) {
+        map.put(name, value);
+      } else if (value instanceof Option) {
+        Map<String, Object> newMap = optionsAsMap(Arrays.asList((Option) value));
+
+        Object oldValue = map.get(name);
+        if (oldValue instanceof Map) {
+          Map<String, Object> oldMap = (Map<String, Object>) oldValue;
+          for (Map.Entry<String, Object> entry : newMap.entrySet()) {
+            oldMap.put(entry.getKey(), entry.getValue());
+          }
+        } else {
+          map.put(name, newMap);
+        }
+      } else if (value instanceof Map) {
+        Object oldValue = map.get(name);
+        if (oldValue instanceof Map) {
+          ((Map<String, Object>) oldValue).putAll((Map<String, Object>) value);
+        } else {
+          map.put(name, value);
+        }
+      } else {
+        throw new AssertionError("Option value must be String, List, or Map<String, ?>");
+      }
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
   private final String name;
   private final Object value;
 

--- a/src/main/java/com/squareup/protoparser/ProtoFile.java
+++ b/src/main/java/com/squareup/protoparser/ProtoFile.java
@@ -2,10 +2,7 @@
 package com.squareup.protoparser;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static java.util.Collections.unmodifiableList;
 
@@ -17,12 +14,12 @@ public final class ProtoFile {
   private final List<String> publicDependencies;
   private final List<Type> types;
   private final List<Service> services;
-  private final Map<String, Object> options;
+  private final List<Option> options;
   private final List<ExtendDeclaration> extendDeclarations;
 
   ProtoFile(String fileName, String packageName, List<String> dependencies,
       List<String> publicDependencies, List<Type> types, List<Service> services,
-      Map<String, Object> options, List<ExtendDeclaration> extendDeclarations) {
+      List<Option> options, List<ExtendDeclaration> extendDeclarations) {
     if (fileName == null) throw new NullPointerException("fileName");
     if (dependencies == null) throw new NullPointerException("dependencies");
     if (publicDependencies == null) throw new NullPointerException("publicDependencies");
@@ -37,15 +34,9 @@ public final class ProtoFile {
     this.publicDependencies = unmodifiableList(new ArrayList<String>(publicDependencies));
     this.types = unmodifiableList(new ArrayList<Type>(types));
     this.services = unmodifiableList(new ArrayList<Service>(services));
-    this.options = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(options));
+    this.options = unmodifiableList(new ArrayList<Option>(options));
     this.extendDeclarations =
         unmodifiableList(new ArrayList<ExtendDeclaration>(extendDeclarations));
-  }
-
-  /** Returns the Java package, or the default package if no Java package is specified. */
-  public String getJavaPackage() {
-    Object javaPackage = options.get("java_package");
-    return javaPackage != null ? (String) javaPackage : packageName;
   }
 
   public String getFileName() {
@@ -72,7 +63,7 @@ public final class ProtoFile {
     return services;
   }
 
-  public Map<String, Object> getOptions() {
+  public List<Option> getOptions() {
     return options;
   }
 
@@ -115,8 +106,11 @@ public final class ProtoFile {
     StringBuilder result = new StringBuilder();
     result.append("fileName: ").append(fileName).append('\n');
     result.append("packageName: ").append(packageName).append('\n');
-    for (Map.Entry<String, Object> option : options.entrySet()) {
-      result.append("option ").append(option.getKey()).append(" = ").append(option.getValue())
+    for (Option option : options) {
+      result.append("option ")
+          .append(option.getName())
+          .append(" = ")
+          .append(option.getValue())
           .append('\n');
     }
     for (String dependency : dependencies) {

--- a/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
@@ -81,7 +81,7 @@ public final class ProtoSchemaParser {
   private final List<ExtendDeclaration> extendDeclarations = new ArrayList<ExtendDeclaration>();
 
   /** Global options. */
-  private final Map<String, Object> options = new LinkedHashMap<String, Object>();
+  private final List<Option> options = new ArrayList<Option>();
 
   ProtoSchemaParser(String fileName, char[] data) {
     this.fileName = fileName;
@@ -124,8 +124,7 @@ public final class ProtoSchemaParser {
       } else if (declaration instanceof Service) {
         services.add((Service) declaration);
       } else if (declaration instanceof Option) {
-        Option option = (Option) declaration;
-        options.put(option.getName(), option.getValue());
+        options.add((Option) declaration);
       } else if (declaration instanceof ExtendDeclaration) {
         extendDeclarations.add((ExtendDeclaration) declaration);
       }
@@ -477,7 +476,7 @@ public final class ProtoSchemaParser {
     String responseType = readName();
     if (readChar() != ')') throw unexpected("expected ')'");
 
-    Map<String, Object> options = new LinkedHashMap<String, Object>();
+    List<Option> options = new ArrayList<Option>();
     if (peekChar() == '{') {
       pos++;
       while (true) {
@@ -488,8 +487,7 @@ public final class ProtoSchemaParser {
         }
         Object declared = readDeclaration(methodDocumentation, Context.RPC);
         if (declared instanceof Option) {
-          Option option = (Option) declared;
-          options.put(option.getName(), option.getValue());
+          options.add((Option) declared);
         }
       }
     } else if (readChar() != ';') throw unexpected("expected ';'");

--- a/src/main/java/com/squareup/protoparser/Service.java
+++ b/src/main/java/com/squareup/protoparser/Service.java
@@ -3,9 +3,7 @@ package com.squareup.protoparser;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 public final class Service {
   private final String name;
@@ -73,10 +71,10 @@ public final class Service {
     private final String documentation;
     private final String requestType;
     private final String responseType;
-    private final Map<String, Object> options;
+    private final List<Option> options;
 
     public Method(String name, String documentation, String requestType, String responseType,
-        Map<String, Object> options) {
+        List<Option> options) {
       if (name == null) throw new NullPointerException("name");
       if (documentation == null) throw new NullPointerException("documentation");
       if (requestType == null) throw new NullPointerException("requestType");
@@ -86,7 +84,7 @@ public final class Service {
       this.documentation = documentation;
       this.requestType = requestType;
       this.responseType = responseType;
-      this.options = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(options));
+      this.options = Collections.unmodifiableList(new ArrayList<Option>(options));
     }
 
     public String getName() {
@@ -105,7 +103,7 @@ public final class Service {
       return responseType;
     }
 
-    public Map<String, Object> getOptions() {
+    public List<Option> getOptions() {
       return options;
     }
 

--- a/src/test/java/com/squareup/protoparser/OptionTest.java
+++ b/src/test/java/com/squareup/protoparser/OptionTest.java
@@ -1,0 +1,46 @@
+package com.squareup.protoparser;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+import static com.squareup.protoparser.TestUtils.list;
+import static com.squareup.protoparser.TestUtils.map;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.data.MapEntry.entry;
+
+public class OptionTest {
+  @Test public void optionListToMap() {
+    List<Option> options = list( //
+        new Option("foo", "bar"), //
+        new Option("ping", list( //
+            new Option("kit", "kat"), //
+            new Option("tic", "tac"), //
+            new Option("up", "down") //
+        )), //
+        new Option("wire", map( //
+            "omar", "little", //
+            "proposition", "joe" //
+        )) //
+        // TODO new Option("(nested.option).one", "two"), //
+        // TODO new Option("(nested.option).three", "four") //
+    );
+    Map<String, Object> optionMap = Option.optionsAsMap(options);
+    assertThat(optionMap).contains( //
+        entry("foo", "bar"), //
+        entry("ping", list( //
+            new Option("kit", "kat"), //
+            new Option("tic", "tac"), //
+            new Option("up", "down") //
+        )), //
+        entry("wire", map( //
+            "omar", "little", //
+            "proposition", "joe" //
+        )) //
+        // TODO entry("nested.option", map( //
+        // TODO     "one", "two", //
+        // TODO     "three", "four" //
+        // TODO )) //
+    );
+  }
+}

--- a/src/test/java/com/squareup/protoparser/TestUtils.java
+++ b/src/test/java/com/squareup/protoparser/TestUtils.java
@@ -1,0 +1,24 @@
+package com.squareup.protoparser;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class TestUtils {
+  static Map<String, Object> map(Object... keysAndValues) {
+    Map<String, Object> result = new LinkedHashMap<String, Object>();
+    for (int i = 0; i < keysAndValues.length; i += 2) {
+      result.put((String) keysAndValues[i], keysAndValues[i + 1]);
+    }
+    return result;
+  }
+
+  static <T> List<T> list(T... values) {
+    return Arrays.asList(values);
+  }
+
+  private TestUtils() {
+    throw new AssertionError("No instances.");
+  }
+}


### PR DESCRIPTION
This is a backwards-incompatible change on Service.Method since it is a return type change on which methods cannot be overloaded.

@swankjesse @danrice-square 
