### PR TITLE
Correct extensions parsing.

### DIFF
--- a/src/main/java/com/squareup/protoparser/Extensions.java
+++ b/src/main/java/com/squareup/protoparser/Extensions.java
@@ -1,6 +1,8 @@
 // Copyright 2013 Square, Inc.
 package com.squareup.protoparser;
 
+import static com.squareup.protoparser.ProtoFile.isValidTag;
+
 public final class Extensions {
   private final String documentation;
   private final int start;
@@ -8,6 +10,8 @@ public final class Extensions {
 
   public Extensions(String documentation, int start, int end) {
     if (documentation == null) throw new NullPointerException("documentation");
+    if (!isValidTag(start)) throw new IllegalArgumentException("Invalid start value: " + start);
+    if (!isValidTag(end)) throw new IllegalArgumentException("Invalid end value: " + end);
 
     this.documentation = documentation;
     this.start = start;

--- a/src/main/java/com/squareup/protoparser/MessageType.java
+++ b/src/main/java/com/squareup/protoparser/MessageType.java
@@ -4,6 +4,7 @@ package com.squareup.protoparser;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.squareup.protoparser.ProtoFile.isValidTag;
 import static java.util.Collections.unmodifiableList;
 
 public final class MessageType implements Type {
@@ -71,6 +72,7 @@ public final class MessageType implements Type {
         && documentation.equals(that.documentation)
         && fields.equals(that.fields)
         && nestedTypes.equals(that.nestedTypes)
+        && extensions.equals(that.extensions)
         && options.equals(that.options);
   }
 
@@ -116,6 +118,7 @@ public final class MessageType implements Type {
         List<Option> options) {
       if (label == null) throw new NullPointerException("label");
       if (type == null) throw new NullPointerException("type");
+      if (!isValidTag(tag)) throw new IllegalArgumentException("Illegal tag value: " + tag);
       if (name == null) throw new NullPointerException("name");
       if (documentation == null) throw new NullPointerException("documentation");
       if (options == null) throw new NullPointerException("options");

--- a/src/main/java/com/squareup/protoparser/ProtoFile.java
+++ b/src/main/java/com/squareup/protoparser/ProtoFile.java
@@ -8,6 +8,17 @@ import static java.util.Collections.unmodifiableList;
 
 /** A single {@code .proto} file. */
 public final class ProtoFile {
+  public static final int MIN_TAG_VALUE = 1;
+  public static final int MAX_TAG_VALUE = (1 << 29) - 1; // 536,870,911
+  private static final int RESERVED_TAG_VALUE_START = 19000;
+  private static final int RESERVED_TAG_VALUE_END = 19999;
+
+  /** True if the supplied value is in the valid tag range and not reserved. */
+  public static boolean isValidTag(int value) {
+    return (value >= MIN_TAG_VALUE && value < RESERVED_TAG_VALUE_START)
+        || (value > RESERVED_TAG_VALUE_END && value <= MAX_TAG_VALUE);
+  }
+
   private final String fileName;
   private final String packageName;
   private final List<String> dependencies;
@@ -80,7 +91,7 @@ public final class ProtoFile {
         && extendDeclarations.equals(that.extendDeclarations)
         && fileName.equals(that.fileName)
         && options.equals(that.options)
-        && packageName == null ? that.packageName == null : packageName.equals(that.packageName)
+        && (packageName == null ? that.packageName == null : packageName.equals(that.packageName))
         && publicDependencies.equals(that.publicDependencies)
         && services.equals(that.services)
         && types.equals(that.types);

--- a/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
@@ -22,8 +22,6 @@ import java.util.Map;
  * within types.
  */
 public final class ProtoSchemaParser {
-  private static final int MAX_TAG_VALUE = (1 << 29) - 1; // 536,870,911
-
   /** Parse a {@code .proto} definition file. */
   public static ProtoFile parse(File file) throws IOException {
     return new ProtoSchemaParser(file.getName(), fileToCharArray(file)).readProtoFile();
@@ -336,10 +334,10 @@ public final class ProtoSchemaParser {
     int start = readInt(); // Range start.
     int end = start;
     if (peekChar() != ';') {
-      readWord(); // Literal 'to'
+      if (!"to".equals(readWord())) throw unexpected("expected ';' or 'to'");
       String s = readWord(); // Range end.
       if (s.equals("max")) {
-        end = MAX_TAG_VALUE;
+        end = ProtoFile.MAX_TAG_VALUE;
       } else {
         end = Integer.parseInt(s);
       }

--- a/src/test/java/com/squareup/protoparser/ProtoFileTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoFileTest.java
@@ -1,0 +1,20 @@
+package com.squareup.protoparser;
+
+import org.junit.Test;
+
+import static com.squareup.protoparser.ProtoFile.MAX_TAG_VALUE;
+import static com.squareup.protoparser.ProtoFile.MIN_TAG_VALUE;
+import static com.squareup.protoparser.ProtoFile.isValidTag;
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class ProtoFileTest {
+  @Test public void tagValueValidation() {
+    assertThat(isValidTag(MIN_TAG_VALUE - 1)).isFalse(); // Less than minimum.
+    assertThat(isValidTag(MIN_TAG_VALUE)).isTrue();
+    assertThat(isValidTag(1234)).isTrue();
+    assertThat(isValidTag(19222)).isFalse(); // Reserved range.
+    assertThat(isValidTag(2319573)).isTrue();
+    assertThat(isValidTag(MAX_TAG_VALUE)).isTrue();
+    assertThat(isValidTag(MAX_TAG_VALUE + 1)).isFalse(); // Greater than maximum.
+  }
+}

--- a/src/test/java/com/squareup/protoparser/ProtoSchemaParserTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoSchemaParserTest.java
@@ -248,7 +248,9 @@ public final class ProtoSchemaParserTest {
         new Option("deprecated", "true"));
 
     Type messageType = new MessageType("FieldOptions", "FieldOptions", "", Arrays.asList(field),
-            Arrays.asList(enumType), NO_EXTENSIONS, NO_OPTIONS);
+        Arrays.asList(enumType), list(new Extensions(
+        "Clients can define custom options in extensions of this message. See above.", 500, 500),
+        new Extensions("", 1000, ProtoFile.MAX_TAG_VALUE)), NO_OPTIONS);
     ProtoFile expected =
         new ProtoFile("descriptor.proto", null, NO_STRINGS, NO_STRINGS, Arrays.asList(messageType),
             NO_SERVICES, NO_OPTIONS, NO_EXTEND_DECLARATIONS);


### PR DESCRIPTION
Two problems were plaguing equality testing:
- `ProtoFile` had a ternary operator improperly scoped which resulted in precedence problems. As a result types, services, and public dependencies were only being compared when the package was not null.
- `MessageType` was not including the list of extensions in its equals check.

@swankjesse @danrice-square 
