### PR TITLE
Remove duplicate tag range check.

### DIFF
--- a/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
@@ -304,7 +304,6 @@ public final class ProtoSchemaParser {
     String name = readName();
     if (readChar() != '=') throw unexpected("expected '='");
     int tag = readInt();
-    if (tag <= 0) throw unexpected("expected tag > 0");
     List<Option> options = new ArrayList<Option>();
 
     if (peekChar() == '[') {

--- a/src/test/java/com/squareup/protoparser/ProtoSchemaParserTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoSchemaParserTest.java
@@ -477,17 +477,4 @@ public final class ProtoSchemaParserTest {
             NO_SERVICES, NO_OPTIONS, NO_EXTEND_DECLARATIONS);
     assertThat(ProtoSchemaParser.parse("foo.proto", proto)).isEqualTo(protoFile);
   }
-
-  @Test public void parseBadTagNumber() throws Exception {
-    String proto = ""
-        + "message BadTagNumber {\n"
-        + "  required int32 a = 0;\n"
-        + "}";
-    try {
-      ProtoSchemaParser.parse("badtag.proto", proto);
-      Fail.fail("Expected parse error");
-    } catch (Exception e) {
-      assertThat(e.getMessage().contains("expected tag > 0"));
-    }
-  }
 }


### PR DESCRIPTION
This check is done at the object level in the MessageType.Field and EnumType.Value constructor.

@swankjesse @danrice-square @adriancole 
