### PR TITLE
Special-case descriptor protos from enum scope rule.

### DIFF
--- a/src/main/java/com/squareup/protoparser/EnumType.java
+++ b/src/main/java/com/squareup/protoparser/EnumType.java
@@ -28,6 +28,11 @@ public final class EnumType implements Type {
    * are siblings of their type, not children of it.
    */
   static void validateValueUniquenessInScope(String type, List<Type> nestedTypes) {
+    // Look for types directly in the proto package but not beneath (e.g., google.protobuf.foo.Bar).
+    if (type.startsWith("google.protobuf.") && type.indexOf('.', 16) == -1) {
+      // Google violates this constraint inside their proto descriptors which never generate code.
+      return;
+    }
     Set<Integer> tags = new LinkedHashSet<Integer>();
     for (Type nestedType : nestedTypes) {
       if (nestedType instanceof EnumType) {

--- a/src/test/java/com/squareup/protoparser/MessageTypeTest.java
+++ b/src/test/java/com/squareup/protoparser/MessageTypeTest.java
@@ -160,4 +160,12 @@ public class MessageTypeTest {
       assertThat(e).hasMessage("Duplicate enum tag 1 in scope example.Message");
     }
   }
+
+  @Test public void duplicateEnumValueTagInDescriptorDoesNotThrow() {
+    Value value = new Value("VALUE", 1, "", NO_OPTIONS);
+    Type enum1 = new EnumType("E1", "google.protobuf.Message.E1", "", NO_OPTIONS, list(value));
+    Type enum2 = new EnumType("E2", "google.protobuf.Message.E2", "", NO_OPTIONS, list(value));
+    new MessageType("Message", "google.protobuf.Message", "", NO_FIELDS, list(enum1, enum2),
+        NO_EXTENSIONS, NO_OPTIONS);
+  }
 }


### PR DESCRIPTION
The protocol buffer descriptors (specifically FieldOptions) contain multiple enums which contain the same value. These protos will never generate code since their representation is inside the runtime which is why they are allowed by protoc.
