### PR TITLE
Support extend declarations that are nested.

### DIFF
--- a/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoSchemaParser.java
@@ -226,6 +226,9 @@ public final class ProtoSchemaParser {
         extensions.add((Extensions) declared);
       } else if (declared instanceof Option) {
         options.add((Option) declared);
+      } else if (declared instanceof ExtendDeclaration) {
+        // Extend declarations always add in a global scope regardless of nesting.
+        extendDeclarations.add((ExtendDeclaration) declared);
       }
     }
     prefix = previousPrefix;
@@ -249,8 +252,11 @@ public final class ProtoSchemaParser {
         fields.add((MessageType.Field) declared);
       }
     }
-    return new ExtendDeclaration(name, name.contains(".") ? name : prefix + name, documentation,
-        fields);
+    String fqname = name;
+    if (!name.contains(".") && packageName != null) {
+      fqname = packageName + "." + name;
+    }
+    return new ExtendDeclaration(name, fqname, documentation, fields);
   }
 
   /** Reads a service declaration and returns it. */

--- a/src/test/java/com/squareup/protoparser/ExtendDeclarationTest.java
+++ b/src/test/java/com/squareup/protoparser/ExtendDeclarationTest.java
@@ -12,14 +12,14 @@ import static org.fest.assertions.api.Assertions.fail;
 
 public class ExtendDeclarationTest {
   @Test public void emptyToString() {
-    ExtendDeclaration extend = new ExtendDeclaration("Name", "", "", NO_FIELDS);
+    ExtendDeclaration extend = new ExtendDeclaration("Name", "Name", "", NO_FIELDS);
     String expected = "extend Name {}\n";
     assertThat(extend.toString()).isEqualTo(expected);
   }
 
   @Test public void simpleToString() {
     Field field = new Field(REQUIRED, "Type", "name", 1, "", NO_OPTIONS);
-    ExtendDeclaration extend = new ExtendDeclaration("Name", "", "", list(field));
+    ExtendDeclaration extend = new ExtendDeclaration("Name", "Name", "", list(field));
     String expected = ""
         + "extend Name {\n"
         + "  required Type name = 1;\n"
@@ -29,7 +29,7 @@ public class ExtendDeclarationTest {
 
   @Test public void simpleWithDocumentationToString() {
     Field field = new Field(REQUIRED, "Type", "name", 1, "", NO_OPTIONS);
-    ExtendDeclaration extend = new ExtendDeclaration("Name", "", "Hello", list(field));
+    ExtendDeclaration extend = new ExtendDeclaration("Name", "Name", "Hello", list(field));
     String expected = ""
         + "// Hello\n"
         + "extend Name {\n"

--- a/src/test/java/com/squareup/protoparser/ProtoFileTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoFileTest.java
@@ -132,7 +132,7 @@ public class ProtoFileTest {
 
   @Test public void simpleWithExtendsToString() {
     Type type = new MessageType("Message", "", "", NO_FIELDS, NO_TYPES, NO_EXTENSIONS, NO_OPTIONS);
-    ExtendDeclaration extend = new ExtendDeclaration("Extend", "", "", NO_FIELDS);
+    ExtendDeclaration extend = new ExtendDeclaration("Extend", "Extend", "", NO_FIELDS);
     ProtoFile file =
         new ProtoFile("file.proto", null, NO_STRINGS, NO_STRINGS, list(type),
             NO_SERVICES, NO_OPTIONS, list(extend));


### PR DESCRIPTION
No matter in what context they are specified (e.g., inside of a message), extend declarations are always treated as being part of the scope of the root of the proto file.

Closes #52 

@danrice-square @swankjesse 
