### PR TITLE
Support 'allow_alias' option in 'enum' declarations.

### DIFF
--- a/src/main/java/com/squareup/protoparser/Option.java
+++ b/src/main/java/com/squareup/protoparser/Option.java
@@ -96,7 +96,9 @@ public final class Option {
 
   @Override public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (value instanceof String) {
+    if (value instanceof Boolean) {
+      builder.append(name).append(" = ").append(value);
+    } else if (value instanceof String) {
       String stringValue = (String) value;
       builder.append(name).append(" = \"").append(escape(stringValue)).append('"');
     } else if (value instanceof Option) {

--- a/src/test/java/com/squareup/protoparser/EnumTypeTest.java
+++ b/src/test/java/com/squareup/protoparser/EnumTypeTest.java
@@ -94,4 +94,21 @@ public class EnumTypeTest {
       assertThat(e).hasMessage("Duplicate tag 1 in example.Enum");
     }
   }
+
+  @Test public void duplicateValueTagWithAllowAlias() {
+    Option option1 = new Option("allow_alias", true);
+    Value value1 = new Value("VALUE1", 1, "", NO_OPTIONS);
+    Value value2 = new Value("VALUE2", 1, "", NO_OPTIONS);
+    EnumType type = new EnumType("Enum1", "example.Enum", "", list(option1), list(value1, value2));
+
+    String expected = ""
+        + "enum Enum1 {\n"
+        + "  option allow_alias = true;\n"
+        + "\n"
+        + "  VALUE1 = 1;\n"
+        + "  VALUE2 = 1;\n"
+        + "}\n";
+
+    assertThat(type.toString()).isEqualTo(expected);
+  }
 }

--- a/src/test/java/com/squareup/protoparser/OptionTest.java
+++ b/src/test/java/com/squareup/protoparser/OptionTest.java
@@ -33,6 +33,12 @@ public class OptionTest {
     assertThat(option.toString()).isEqualTo(expected);
   }
 
+  @Test public void booleanToString() {
+    Option option = new Option("foo", false);
+    String expected = "foo = false";
+    assertThat(option.toString()).isEqualTo(expected);
+  }
+
   @Test public void optionListToMap() {
     List<Option> options = list( //
         new Option("foo", "bar"), //


### PR DESCRIPTION
Closes #56.
