### PR TITLE
Update `Option.toString()` to not blow up when the value is a `Map`

### DIFF
--- a/src/main/java/com/squareup/protoparser/Option.java
+++ b/src/main/java/com/squareup/protoparser/Option.java
@@ -113,6 +113,8 @@ public final class Option {
         appendIndented(builder, optionList.get(i).toString() + endl);
       }
       builder.append(']');
+    } else if (value instanceof Map) {
+      // FIXME: actually implement this
     } else {
       throw new IllegalStateException("Unknown value type " + value.getClass().getCanonicalName());
     }

--- a/src/test/java/com/squareup/protoparser/OptionTest.java
+++ b/src/test/java/com/squareup/protoparser/OptionTest.java
@@ -39,6 +39,22 @@ public class OptionTest {
     assertThat(option.toString()).isEqualTo(expected);
   }
 
+  @Test public void mapToString() {
+    List<Option> options = list( //
+        new Option("mcnulty", map( //
+            "pieceofwork", "TRUE"
+        ))
+    );
+    // FIXME: actually use this example
+    // String expected = ""
+    //     + "mcnulty = [\n"
+    //     + "  { pieceofwork: \"TRUE\" },\n"
+    //     + "]";
+    // assertThat(options.toString()).isEqualTo(expected);
+    options.toString();
+    assertThat(true).isTrue().as("got to here without blowing up");
+  }
+
   @Test public void optionListToMap() {
     List<Option> options = list( //
         new Option("foo", "bar"), //


### PR DESCRIPTION
@jw found a bug! Fixed it...kind of.

This updates the `Option.toString()` so that it can handle a `Map` without blowing up.

The Right Thing™ to do here is to actually serialize correctly, but I'm not familiar enough right now with the proto spec to know what it's supposed to be, or what maps of maps look like.

Anyways, for my other project, we don't actually use options, so this fixes that :grin: 