### PR TITLE
Format multiple options on an enum value correctly

### DIFF
--- a/src/main/java/com/squareup/protoparser/EnumType.java
+++ b/src/main/java/com/squareup/protoparser/EnumType.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.squareup.protoparser.Option.formatOptionList;
 import static com.squareup.protoparser.Utils.appendDocumentation;
 import static com.squareup.protoparser.Utils.appendIndented;
 import static java.util.Collections.unmodifiableList;
@@ -210,9 +211,7 @@ public final class EnumType implements Type {
           .append(tag);
       if (!options.isEmpty()) {
         builder.append(" [\n");
-        for (Option option : options) {
-          appendIndented(builder, option.toString());
-        }
+        formatOptionList(builder, options);
         builder.append(']');
       }
       return builder.append(";\n").toString();

--- a/src/main/java/com/squareup/protoparser/Option.java
+++ b/src/main/java/com/squareup/protoparser/Option.java
@@ -108,10 +108,7 @@ public final class Option {
       builder.append(name).append(" = [\n");
       //noinspection unchecked
       List<Option> optionList = (List<Option>) value;
-      for (int i = 0, count = optionList.size(); i < count; i++) {
-        String endl = (i < count - 1) ? "," : "";
-        appendIndented(builder, optionList.get(i).toString() + endl);
-      }
+      formatOptionList(builder, optionList);
       builder.append(']');
     } else {
       throw new IllegalStateException("Unknown value type " + value.getClass().getCanonicalName());
@@ -129,5 +126,13 @@ public final class Option {
         .replace("\"", "\\\"")
         .replace("\r", "\\r")
         .replace("\n", "\\n");
+  }
+
+  static StringBuilder formatOptionList(StringBuilder builder, List<Option> optionList) {
+    for (int i = 0, count = optionList.size(); i < count; i++) {
+      String endl = (i < count - 1) ? "," : "";
+      appendIndented(builder, optionList.get(i).toString() + endl);
+    }
+    return builder;
   }
 }

--- a/src/test/java/com/squareup/protoparser/EnumTypeTest.java
+++ b/src/test/java/com/squareup/protoparser/EnumTypeTest.java
@@ -77,9 +77,10 @@ public class EnumTypeTest {
   }
 
   @Test public void fieldWithOptions() {
-    Value value = new Value("NAME", 1, "", list(new Option("kit", "kat")));
+    Value value = new Value("NAME", 1, "", list(new Option("kit", "kat"), new Option("tit", "tat")));
     String expected = "NAME = 1 [\n"
-        + "  kit = \"kat\"\n"
+        + "  kit = \"kat\",\n"
+        + "  tit = \"tat\"\n"
         + "];\n";
     assertThat(value.toString()).isEqualTo(expected);
   }


### PR DESCRIPTION
@JakeWharton

Options on enum values were not correctly getting commas between fixed, by sharing code with `Option.toString()`
