### PR TITLE
Add option creation overload for non-parenthesized name.

### DIFF
--- a/src/main/java/com/squareup/protoparser/OptionElement.java
+++ b/src/main/java/com/squareup/protoparser/OptionElement.java
@@ -66,6 +66,10 @@ public abstract class OptionElement {
     return found;
   }
 
+  public static OptionElement create(String name, Object value) {
+    return create(name, value, false);
+  }
+
   public static OptionElement create(String name, Object value, boolean isParenthesized) {
     checkNotNull(name, "name");
     checkNotNull(value, "value");
@@ -91,7 +95,7 @@ public abstract class OptionElement {
     } else if (value instanceof OptionElement) {
       OptionElement optionValue = (OptionElement) value;
       // Treat nested options as non-parenthesized always, prevents double parentheses.
-      optionValue = OptionElement.create(optionValue.name(), optionValue.value(), false);
+      optionValue = OptionElement.create(optionValue.name(), optionValue.value());
       builder.append(formatName()).append('.').append(optionValue.toString());
     } else if (value instanceof EnumConstantElement) {
       EnumConstantElement enumValue = (EnumConstantElement) value;

--- a/src/main/java/com/squareup/protoparser/ProtoParser.java
+++ b/src/main/java/com/squareup/protoparser/ProtoParser.java
@@ -401,7 +401,7 @@ public final class ProtoParser {
     }
     Object value = readValue();
     Object valueOrSubOption =
-        subName != null ? OptionElement.create(subName, value, isParenthesized) : value;
+        subName != null ? OptionElement.create(subName, value) : value;
     return OptionElement.create(name, valueOrSubOption, isParenthesized);
   }
 

--- a/src/test/java/com/squareup/protoparser/EnumElementTest.java
+++ b/src/test/java/com/squareup/protoparser/EnumElementTest.java
@@ -79,7 +79,7 @@ public class EnumElementTest {
   @Test public void simpleWithOptionsToString() {
     EnumElement element = EnumElement.builder()
         .name("Enum")
-        .addOption(OptionElement.create("kit", "kat", false))
+        .addOption(OptionElement.create("kit", "kat"))
         .addConstant(EnumConstantElement.builder().name("ONE").tag(1).build())
         .addConstant(EnumConstantElement.builder().name("TWO").tag(2).build())
         .addConstant(EnumConstantElement.builder().name("SIX").tag(6).build())
@@ -136,7 +136,7 @@ public class EnumElementTest {
         .name("NAME")
         .tag(1)
         .addOption(OptionElement.create("kit", "kat", true))
-        .addOption(OptionElement.create("tit", "tat", false))
+        .addOption(OptionElement.create("tit", "tat"))
         .build();
     String expected = "NAME = 1 [\n"
         + "  (kit) = \"kat\",\n"
@@ -163,7 +163,7 @@ public class EnumElementTest {
     EnumElement element = EnumElement.builder()
         .name("Enum1")
         .qualifiedName("example.Enum")
-        .addOption(OptionElement.create("allow_alias", true, false))
+        .addOption(OptionElement.create("allow_alias", true))
         .addConstant(EnumConstantElement.builder().name("VALUE1").tag(1).build())
         .addConstant(EnumConstantElement.builder().name("VALUE2").tag(1).build())
         .build();

--- a/src/test/java/com/squareup/protoparser/MessageElementTest.java
+++ b/src/test/java/com/squareup/protoparser/MessageElementTest.java
@@ -128,7 +128,7 @@ public class MessageElementTest {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(field)
-        .addOption(OptionElement.create("kit", "kat", false))
+        .addOption(OptionElement.create("kit", "kat"))
         .build();
     String expected = ""
         + "message Message {\n"
@@ -247,7 +247,7 @@ public class MessageElementTest {
     ExtensionsElement extensions1 = ExtensionsElement.create(500, 501);
     ExtensionsElement extensions2 = ExtensionsElement.create(503, 503);
     TypeElement nested = MessageElement.builder().name("Nested").addField(field1).build();
-    OptionElement option = OptionElement.create("kit", "kat", false);
+    OptionElement option = OptionElement.create("kit", "kat");
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(field1)
@@ -325,7 +325,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name")
         .tag(1)
-        .addOption(OptionElement.create("kit", "kat", false))
+        .addOption(OptionElement.create("kit", "kat"))
         .build();
     String expected = "required string name = 1 [\n"
         + "  kit = \"kat\"\n"
@@ -437,7 +437,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", "true", false))
+        .addOption(OptionElement.create("deprecated", "true"))
         .build();
     assertThat(field.isDeprecated()).isTrue();
   }
@@ -448,7 +448,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", "false", false))
+        .addOption(OptionElement.create("deprecated", "false"))
         .build();
     assertThat(field.isDeprecated()).isFalse();
   }
@@ -469,7 +469,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("packed", "true", false))
+        .addOption(OptionElement.create("packed", "true"))
         .build();
     assertThat(field.isPacked()).isTrue();
   }
@@ -480,7 +480,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("packed", "false", false))
+        .addOption(OptionElement.create("packed", "false"))
         .build();
     assertThat(field.isPacked()).isFalse();
   }
@@ -501,7 +501,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("default", "foo", false))
+        .addOption(OptionElement.create("default", "foo"))
         .build();
     assertThat(field.getDefault()).isEqualTo("foo");
   }

--- a/src/test/java/com/squareup/protoparser/OptionElementTest.java
+++ b/src/test/java/com/squareup/protoparser/OptionElementTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.fail;
 public class OptionElementTest {
   @Test public void nullNameThrows() {
     try {
-      OptionElement.create(null, "Test", true);
+      OptionElement.create(null, "Test");
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("name == null");
@@ -22,7 +22,7 @@ public class OptionElementTest {
 
   @Test public void nullValueThrows() {
     try {
-      OptionElement.create("test", null, true);
+      OptionElement.create("test", null);
       fail();
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("value == null");
@@ -30,22 +30,21 @@ public class OptionElementTest {
   }
 
   @Test public void simpleToString() {
-    OptionElement option = OptionElement.create("foo", "bar", false);
+    OptionElement option = OptionElement.create("foo", "bar");
     String expected = "foo = \"bar\"";
     assertThat(option.toString()).isEqualTo(expected);
   }
 
   @Test public void nestedToString() {
     OptionElement option =
-        OptionElement.create("foo.boo", OptionElement.create("bar", "baz", true), true);
+        OptionElement.create("foo.boo", OptionElement.create("bar", "baz"), true);
     String expected = "(foo.boo).bar = \"baz\"";
     assertThat(option.toString()).isEqualTo(expected);
   }
 
   @Test public void listToString() {
     OptionElement option = OptionElement.create("foo",
-        list(OptionElement.create("ping", "pong", true), OptionElement.create("kit", "kat", false)),
-        true);
+        list(OptionElement.create("ping", "pong", true), OptionElement.create("kit", "kat")), true);
     String expected = ""
         + "(foo) = [\n"
         + "  (ping) = \"pong\",\n"
@@ -55,33 +54,33 @@ public class OptionElementTest {
   }
 
   @Test public void booleanToString() {
-    OptionElement option = OptionElement.create("foo", false, false);
+    OptionElement option = OptionElement.create("foo", false);
     String expected = "foo = false";
     assertThat(option.toString()).isEqualTo(expected);
   }
 
   @Test public void optionListToMap() {
     List<OptionElement> options = list( //
-        OptionElement.create("foo", "bar", false), //
+        OptionElement.create("foo", "bar"), //
         OptionElement.create("ping", list( //
-            OptionElement.create("kit", "kat", false), //
-            OptionElement.create("tic", "tac", false), //
-            OptionElement.create("up", "down", false) //
-        ), false), //
+            OptionElement.create("kit", "kat"), //
+            OptionElement.create("tic", "tac"), //
+            OptionElement.create("up", "down") //
+        )), //
         OptionElement.create("wire", map( //
             "omar", "little", //
             "proposition", "joe" //
-        ), false), //
-        OptionElement.create("nested.option", OptionElement.create("one", "two", false), false), //
-        OptionElement.create("nested.option", OptionElement.create("three", "four", false), false) //
+        )), //
+        OptionElement.create("nested.option", OptionElement.create("one", "two")), //
+        OptionElement.create("nested.option", OptionElement.create("three", "four")) //
     );
     Map<String, Object> optionMap = OptionElement.optionsAsMap(options);
     assertThat(optionMap).contains( //
         entry("foo", "bar"), //
         entry("ping", list( //
-            OptionElement.create("kit", "kat", false), //
-            OptionElement.create("tic", "tac", false), //
-            OptionElement.create("up", "down", false) //
+            OptionElement.create("kit", "kat"), //
+            OptionElement.create("tic", "tac"), //
+            OptionElement.create("up", "down") //
         )), //
         entry("wire", map( //
             "omar", "little", //
@@ -95,9 +94,9 @@ public class OptionElementTest {
   }
 
   @Test public void findInList() {
-    OptionElement one = OptionElement.create("one", "1", false);
-    OptionElement two = OptionElement.create("two", "2", false);
-    OptionElement three = OptionElement.create("three", "3", false);
+    OptionElement one = OptionElement.create("one", "1");
+    OptionElement two = OptionElement.create("two", "2");
+    OptionElement three = OptionElement.create("three", "3");
     List<OptionElement> options = list(one, two, three);
     assertThat(OptionElement.findByName(options, "one")).isSameAs(one);
     assertThat(OptionElement.findByName(options, "two")).isSameAs(two);
@@ -105,15 +104,15 @@ public class OptionElementTest {
   }
 
   @Test public void findInListMissing() {
-    OptionElement one = OptionElement.create("one", "1", false);
-    OptionElement two = OptionElement.create("two", "2", false);
+    OptionElement one = OptionElement.create("one", "1");
+    OptionElement two = OptionElement.create("two", "2");
     List<OptionElement> options = list(one, two);
     assertThat(OptionElement.findByName(options, "three")).isNull();
   }
 
   @Test public void findInListDuplicate() {
-    OptionElement one = OptionElement.create("one", "1", false);
-    OptionElement two = OptionElement.create("two", "2", false);
+    OptionElement one = OptionElement.create("one", "1");
+    OptionElement two = OptionElement.create("two", "2");
     List<OptionElement> options = list(one, two, one);
     try {
       OptionElement.findByName(options, "one");

--- a/src/test/java/com/squareup/protoparser/ProtoFileTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoFileTest.java
@@ -161,7 +161,7 @@ public class ProtoFileTest {
 
   @Test public void simpleWithOptionsToString() {
     TypeElement element = MessageElement.builder().name("Message").build();
-    OptionElement option = OptionElement.create("kit", "kat", false);
+    OptionElement option = OptionElement.create("kit", "kat");
     ProtoFile file = ProtoFile.builder("file.proto").addOption(option).addType(element).build();
     String expected = ""
         + "// file.proto\n"
@@ -203,8 +203,8 @@ public class ProtoFileTest {
         .name("Extend2")
         .qualifiedName("example.simple.Extend2")
         .build();
-    OptionElement option1 = OptionElement.create("kit", "kat", false);
-    OptionElement option2 = OptionElement.create("foo", "bar", false);
+    OptionElement option1 = OptionElement.create("kit", "kat");
+    OptionElement option2 = OptionElement.create("foo", "bar");
     ServiceElement service1 = ServiceElement.builder()
         .name("Service1")
         .qualifiedName("example.simple.Service1")

--- a/src/test/java/com/squareup/protoparser/ProtoParserTest.java
+++ b/src/test/java/com/squareup/protoparser/ProtoParserTest.java
@@ -122,14 +122,14 @@ public final class ProtoParserTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("default", "STRING", false))
-        .addOption(OptionElement.create("deprecated", "true", false))
+        .addOption(OptionElement.create("default", "STRING"))
+        .addOption(OptionElement.create("deprecated", "true"))
         .build();
     assertThat(field.isDeprecated()).isTrue();
     assertThat(field.getDefault()).isEqualTo("STRING");
     assertThat(field.options()).containsOnly( //
-        OptionElement.create("default", "STRING", false), //
-        OptionElement.create("deprecated", "true", false));
+        OptionElement.create("default", "STRING"), //
+        OptionElement.create("deprecated", "true"));
   }
 
   @Test public void singleLineComment() {
@@ -502,7 +502,7 @@ public final class ProtoParserTest {
             .documentation(
                 "The protocol compiler can output a FileDescriptorSet containing the .proto\nfiles it parses.")
             .build())
-        .addOption(OptionElement.create("java_package", "com.google.protobuf", false))
+        .addOption(OptionElement.create("java_package", "com.google.protobuf"))
         .build();
     assertThat(ProtoParser.parse("descriptor.proto", proto)).isEqualTo(expected);
   }
@@ -533,12 +533,12 @@ public final class ProtoParserTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("default", EnumConstantElement.anonymous("STRING"), false))
-        .addOption(OptionElement.create("deprecated", true, false))
+        .addOption(OptionElement.create("default", EnumConstantElement.anonymous("STRING")))
+        .addOption(OptionElement.create("deprecated", true))
         .build();
     assertThat(field.options()).containsOnly( //
-        OptionElement.create("default", EnumConstantElement.anonymous("STRING"), false), //
-        OptionElement.create("deprecated", true, false));
+        OptionElement.create("default", EnumConstantElement.anonymous("STRING")), //
+        OptionElement.create("deprecated", true));
 
     TypeElement messageElement = MessageElement.builder()
         .name("FieldOptions")
@@ -570,7 +570,7 @@ public final class ProtoParserTest {
                 .type(BOOL)
                 .name("koka_ko_koka_ko")
                 .tag(1)
-                .addOption(OptionElement.create("default", true, false))
+                .addOption(OptionElement.create("default", true))
                 .build())
             .addField(FieldElement.builder()
                 .label(OPTIONAL)
@@ -578,14 +578,14 @@ public final class ProtoParserTest {
                 .name("coodle_doodle_do")
                 .tag(2)
                 .addOption(OptionElement.create("delay", 100, true))
-                .addOption(OptionElement.create("default", false, false))
+                .addOption(OptionElement.create("default", false))
                 .build())
             .addField(FieldElement.builder()
                 .label(OPTIONAL)
                 .type(BOOL)
                 .name("coo_coo_ca_cha")
                 .tag(3)
-                .addOption(OptionElement.create("default", true, false))
+                .addOption(OptionElement.create("default", true))
                 .addOption(OptionElement.create("delay", 200, true))
                 .build())
             .addField(FieldElement.builder()
@@ -761,11 +761,10 @@ public final class ProtoParserTest {
         .name("name")
         .tag(1)
         .addOption(OptionElement.create("default",
-            "\u0007\b\f\n\r\t\u000b\u0001f\u0001\u0001\u0009\u0009I\u000e\u000e\u000e\u000eAA",
-            false))
+            "\u0007\b\f\n\r\t\u000b\u0001f\u0001\u0001\u0009\u0009I\u000e\u000e\u000e\u000eAA"))
         .build();
     assertThat(field.options()).containsOnly(OptionElement.create("default",
-        "\u0007\b\f\n\r\t\u000b\u0001f\u0001\u0001\u0009\u0009I\u000e\u000e\u000e\u000eAA", false));
+        "\u0007\b\f\n\r\t\u000b\u0001f\u0001\u0001\u0009\u0009I\u000e\u000e\u000e\u000eAA"));
 
     TypeElement messageElement = MessageElement.builder().name("Foo").addField(field).build();
     ProtoFile expected = ProtoFile.builder("foo.proto").addType(messageElement).build();
@@ -952,14 +951,14 @@ public final class ProtoParserTest {
         .name("bar")
         .tag(1)
         .addOption(
-            OptionElement.create("validation.range", OptionElement.create("min", 1, true), true))
-        .addOption(OptionElement.create("validation.range", OptionElement.create("max", 100, true), true))
-        .addOption(OptionElement.create("default", 20, false))
+            OptionElement.create("validation.range", OptionElement.create("min", 1), true))
+        .addOption(OptionElement.create("validation.range", OptionElement.create("max", 100), true))
+        .addOption(OptionElement.create("default", 20))
         .build();
     assertThat(field.options()).containsOnly( //
-        OptionElement.create("validation.range", OptionElement.create("min", 1, true), true), //
-        OptionElement.create("validation.range", OptionElement.create("max", 100, true), true), //
-        OptionElement.create("default", 20, false));
+        OptionElement.create("validation.range", OptionElement.create("min", 1), true), //
+        OptionElement.create("validation.range", OptionElement.create("max", 100), true), //
+        OptionElement.create("default", 20));
 
     TypeElement expected = MessageElement.builder().name("Foo").addField(field).build();
     ProtoFile protoFile = ProtoFile.builder("foo.proto").addType(expected).build();

--- a/src/test/java/com/squareup/protoparser/ServiceElementTest.java
+++ b/src/test/java/com/squareup/protoparser/ServiceElementTest.java
@@ -80,7 +80,7 @@ public class ServiceElementTest {
   @Test public void singleWithOptionsToString() {
     ServiceElement service = ServiceElement.builder()
         .name("Service")
-        .addOption(OptionElement.create("foo", "bar", false))
+        .addOption(OptionElement.create("foo", "bar"))
         .addRpc(RpcElement.builder()
             .name("Name")
             .requestType(NamedType.create("RequestType"))
@@ -158,7 +158,7 @@ public class ServiceElementTest {
         .name("Name")
         .requestType(NamedType.create("RequestType"))
         .responseType(NamedType.create("ResponseType"))
-        .addOption(OptionElement.create("foo", "bar", false))
+        .addOption(OptionElement.create("foo", "bar"))
         .build();
     String expected = ""
         + "rpc Name (RequestType) returns (ResponseType) {\n"


### PR DESCRIPTION
This is the common case so it's worth supporting in the API, especially since it avoids a boolean parameter.