### PR TITLE
Option value scalars are now always strings but include type information.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -77,7 +77,7 @@
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
-        <module name="AvoidNestedBlocks"/>
+        <!--<module name="AvoidNestedBlocks"/>-->
         <!--module name="EmptyBlock"/-->
         <module name="LeftCurly"/>
         <!--module name="NeedBraces"/-->

--- a/src/main/java/com/squareup/protoparser/EnumConstantElement.java
+++ b/src/main/java/com/squareup/protoparser/EnumConstantElement.java
@@ -13,13 +13,6 @@ import static com.squareup.protoparser.Utils.immutableCopyOf;
 /** An enum constant. */
 @AutoValue
 public abstract class EnumConstantElement {
-  public static final int UNKNOWN_TAG = -1;
-
-  /** Used to represent enums constants where we just know the name. */
-  static EnumConstantElement anonymous(String name) {
-    return builder().name(name).tag(UNKNOWN_TAG).build();
-  }
-
   public static Builder builder() {
     return new Builder();
   }
@@ -32,7 +25,7 @@ public abstract class EnumConstantElement {
   public abstract String documentation();
   public abstract List<OptionElement> options();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append(name())

--- a/src/main/java/com/squareup/protoparser/EnumElement.java
+++ b/src/main/java/com/squareup/protoparser/EnumElement.java
@@ -32,11 +32,7 @@ public abstract class EnumElement implements TypeElement {
 
   private static boolean parseAllowAlias(List<OptionElement> options) {
     OptionElement option = OptionElement.findByName(options, "allow_alias");
-    if (option != null) {
-      Object value = option.value();
-      return value instanceof Boolean && (Boolean) value;
-    }
-    return false;
+    return option != null && "true".equals(option.value());
   }
 
   /**
@@ -77,7 +73,7 @@ public abstract class EnumElement implements TypeElement {
     return Collections.emptyList(); // Enums do not allow nested type declarations.
   }
 
-  @Override public final String toString() {
+  @Override public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("enum ")
@@ -86,13 +82,13 @@ public abstract class EnumElement implements TypeElement {
     if (!options().isEmpty()) {
       builder.append('\n');
       for (OptionElement option : options()) {
-        appendIndented(builder, option.toDeclaration());
+        appendIndented(builder, option.toSchemaDeclaration());
       }
     }
     if (!constants().isEmpty()) {
       builder.append('\n');
       for (EnumConstantElement constant : constants()) {
-        appendIndented(builder, constant.toString());
+        appendIndented(builder, constant.toSchema());
       }
     }
     return builder.append("}\n").toString();

--- a/src/main/java/com/squareup/protoparser/ExtendElement.java
+++ b/src/main/java/com/squareup/protoparser/ExtendElement.java
@@ -27,7 +27,7 @@ public abstract class ExtendElement {
   public abstract String documentation();
   public abstract List<FieldElement> fields();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("extend ")
@@ -36,7 +36,7 @@ public abstract class ExtendElement {
     if (!fields().isEmpty()) {
       builder.append('\n');
       for (FieldElement field : fields()) {
-        appendIndented(builder, field.toString());
+        appendIndented(builder, field.toSchema());
       }
     }
     return builder.append("}\n").toString();

--- a/src/main/java/com/squareup/protoparser/ExtensionsElement.java
+++ b/src/main/java/com/squareup/protoparser/ExtensionsElement.java
@@ -27,7 +27,7 @@ public abstract class ExtensionsElement {
   public abstract int start();
   public abstract int end();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("extensions ")

--- a/src/main/java/com/squareup/protoparser/FieldElement.java
+++ b/src/main/java/com/squareup/protoparser/FieldElement.java
@@ -38,22 +38,22 @@ public abstract class FieldElement {
   /** Returns true when the {@code deprecated} option is present and set to true. */
   public final boolean isDeprecated() {
     OptionElement deprecatedOption = OptionElement.findByName(options(), "deprecated");
-    return deprecatedOption != null && "true".equals(String.valueOf(deprecatedOption.value()));
+    return deprecatedOption != null && "true".equals(deprecatedOption.value());
   }
 
   /** Returns true when the {@code packed} option is present and set to true. */
   public final boolean isPacked() {
     OptionElement packedOption = OptionElement.findByName(options(), "packed");
-    return packedOption != null && "true".equals(String.valueOf(packedOption.value()));
+    return packedOption != null && "true".equals(packedOption.value());
   }
 
   /** Returns the {@code default} option value or {@code null}. */
-  public final Object getDefault() {
+  public final OptionElement getDefault() {
     OptionElement defaultOption = OptionElement.findByName(options(), "default");
-    return defaultOption != null ? defaultOption.value() : null;
+    return defaultOption != null ? defaultOption : null;
   }
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     if (label() != Label.ONE_OF) {
@@ -67,7 +67,7 @@ public abstract class FieldElement {
     if (!options().isEmpty()) {
       builder.append(" [\n");
       for (OptionElement option : options()) {
-        appendIndented(builder, option.toString());
+        appendIndented(builder, option.toSchema());
       }
       builder.append(']');
     }

--- a/src/main/java/com/squareup/protoparser/MessageElement.java
+++ b/src/main/java/com/squareup/protoparser/MessageElement.java
@@ -59,7 +59,7 @@ public abstract class MessageElement implements TypeElement {
   public abstract List<ExtensionsElement> extensions();
   @Override public abstract List<OptionElement> options();
 
-  @Override public final String toString() {
+  @Override public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("message ")
@@ -68,31 +68,31 @@ public abstract class MessageElement implements TypeElement {
     if (!options().isEmpty()) {
       builder.append('\n');
       for (OptionElement option : options()) {
-        appendIndented(builder, option.toDeclaration());
+        appendIndented(builder, option.toSchemaDeclaration());
       }
     }
     if (!fields().isEmpty()) {
       builder.append('\n');
       for (FieldElement field : fields()) {
-        appendIndented(builder, field.toString());
+        appendIndented(builder, field.toSchema());
       }
     }
     if (!oneOfs().isEmpty()) {
       builder.append('\n');
       for (OneOfElement oneOf : oneOfs()) {
-        appendIndented(builder, oneOf.toString());
+        appendIndented(builder, oneOf.toSchema());
       }
     }
     if (!extensions().isEmpty()) {
       builder.append('\n');
       for (ExtensionsElement extension : extensions()) {
-        appendIndented(builder, extension.toString());
+        appendIndented(builder, extension.toSchema());
       }
     }
     if (!nestedElements().isEmpty()) {
       builder.append('\n');
       for (TypeElement type : nestedElements()) {
-        appendIndented(builder, type.toString());
+        appendIndented(builder, type.toSchema());
       }
     }
     return builder.append("}\n").toString();

--- a/src/main/java/com/squareup/protoparser/OneOfElement.java
+++ b/src/main/java/com/squareup/protoparser/OneOfElement.java
@@ -24,14 +24,14 @@ public abstract class OneOfElement {
   public abstract String documentation();
   public abstract List<FieldElement> fields();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("oneof ").append(name()).append(" {");
     if (!fields().isEmpty()) {
       builder.append('\n');
       for (FieldElement field : fields()) {
-        appendIndented(builder, field.toString());
+        appendIndented(builder, field.toSchema());
       }
     }
     return builder.append("}\n").toString();

--- a/src/main/java/com/squareup/protoparser/ProtoFile.java
+++ b/src/main/java/com/squareup/protoparser/ProtoFile.java
@@ -53,7 +53,7 @@ public abstract class ProtoFile {
   public abstract List<ExtendElement> extendDeclarations();
   public abstract List<OptionElement> options();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     if (!filePath().isEmpty()) {
       builder.append("// ").append(filePath()).append('\n');
@@ -76,25 +76,25 @@ public abstract class ProtoFile {
     if (!options().isEmpty()) {
       builder.append('\n');
       for (OptionElement option : options()) {
-        builder.append(option.toDeclaration());
+        builder.append(option.toSchemaDeclaration());
       }
     }
     if (!typeElements().isEmpty()) {
       builder.append('\n');
       for (TypeElement typeElement : typeElements()) {
-        builder.append(typeElement);
+        builder.append(typeElement.toSchema());
       }
     }
     if (!extendDeclarations().isEmpty()) {
       builder.append('\n');
       for (ExtendElement extendDeclaration : extendDeclarations()) {
-        builder.append(extendDeclaration);
+        builder.append(extendDeclaration.toSchema());
       }
     }
     if (!services().isEmpty()) {
       builder.append('\n');
       for (ServiceElement service : services()) {
-        builder.append(service);
+        builder.append(service.toSchema());
       }
     }
     return builder.toString();

--- a/src/main/java/com/squareup/protoparser/RpcElement.java
+++ b/src/main/java/com/squareup/protoparser/RpcElement.java
@@ -27,7 +27,7 @@ public abstract class RpcElement {
   public abstract NamedType responseType();
   public abstract List<OptionElement> options();
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("rpc ")
@@ -40,7 +40,7 @@ public abstract class RpcElement {
     if (!options().isEmpty()) {
       builder.append(" {\n");
       for (OptionElement option : options()) {
-        appendIndented(builder, option.toDeclaration());
+        appendIndented(builder, option.toSchemaDeclaration());
       }
       builder.append("}");
     }

--- a/src/main/java/com/squareup/protoparser/ServiceElement.java
+++ b/src/main/java/com/squareup/protoparser/ServiceElement.java
@@ -26,7 +26,7 @@ public abstract class ServiceElement {
   ServiceElement() {
   }
 
-  @Override public final String toString() {
+  public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("service ")
@@ -35,13 +35,13 @@ public abstract class ServiceElement {
     if (!options().isEmpty()) {
       builder.append('\n');
       for (OptionElement option : options()) {
-        appendIndented(builder, option.toDeclaration());
+        appendIndented(builder, option.toSchemaDeclaration());
       }
     }
     if (!rpcs().isEmpty()) {
       builder.append('\n');
       for (RpcElement rpc : rpcs()) {
-        appendIndented(builder, rpc.toString());
+        appendIndented(builder, rpc.toSchema());
       }
     }
     return builder.append("}\n").toString();

--- a/src/main/java/com/squareup/protoparser/TypeElement.java
+++ b/src/main/java/com/squareup/protoparser/TypeElement.java
@@ -10,4 +10,5 @@ public interface TypeElement {
   String documentation();
   List<OptionElement> options();
   List<TypeElement> nestedElements();
+  String toSchema();
 }

--- a/src/test/java/com/squareup/protoparser/EnumElementTest.java
+++ b/src/test/java/com/squareup/protoparser/EnumElementTest.java
@@ -4,6 +4,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
 
+import static com.squareup.protoparser.OptionElement.Kind.BOOLEAN;
+import static com.squareup.protoparser.OptionElement.Kind.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -80,13 +82,13 @@ public class EnumElementTest {
     }
   }
 
-  @Test public void emptyToString() {
+  @Test public void emptyToSchema() {
     EnumElement element = EnumElement.builder().name("Enum").build();
     String expected = "enum Enum {}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void simpleToString() {
+  @Test public void simpleToSchema() {
     EnumElement element = EnumElement.builder()
         .name("Enum")
         .addConstant(EnumConstantElement.builder().name("ONE").tag(1).build())
@@ -99,7 +101,7 @@ public class EnumElementTest {
         + "  TWO = 2;\n"
         + "  SIX = 6;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleConstants() {
@@ -110,19 +112,13 @@ public class EnumElementTest {
         .name("Enum")
         .addConstants(Arrays.asList(one, two, six))
         .build();
-    String expected = ""
-        + "enum Enum {\n"
-        + "  ONE = 1;\n"
-        + "  TWO = 2;\n"
-        + "  SIX = 6;\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.constants()).hasSize(3);
   }
 
-  @Test public void simpleWithOptionsToString() {
+  @Test public void simpleWithOptionsToSchema() {
     EnumElement element = EnumElement.builder()
         .name("Enum")
-        .addOption(OptionElement.create("kit", "kat"))
+        .addOption(OptionElement.create("kit", STRING, "kat"))
         .addConstant(EnumConstantElement.builder().name("ONE").tag(1).build())
         .addConstant(EnumConstantElement.builder().name("TWO").tag(2).build())
         .addConstant(EnumConstantElement.builder().name("SIX").tag(6).build())
@@ -135,28 +131,21 @@ public class EnumElementTest {
         + "  TWO = 2;\n"
         + "  SIX = 6;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleOptions() {
-    OptionElement kitKat = OptionElement.create("kit", "kat");
-    OptionElement fooBar = OptionElement.create("foo", "bar");
+    OptionElement kitKat = OptionElement.create("kit", STRING, "kat");
+    OptionElement fooBar = OptionElement.create("foo", STRING, "bar");
     EnumElement element = EnumElement.builder()
         .name("Enum")
         .addOptions(Arrays.asList(kitKat, fooBar))
         .addConstant(EnumConstantElement.builder().name("ONE").tag(1).build())
         .build();
-    String expected = ""
-        + "enum Enum {\n"
-        + "  option kit = \"kat\";\n"
-        + "  option foo = \"bar\";\n"
-        + "\n"
-        + "  ONE = 1;\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.options()).hasSize(2);
   }
 
-  @Test public void simpleWithDocumentationToString() {
+  @Test public void simpleWithDocumentationToSchema() {
     EnumElement element = EnumElement.builder()
         .name("Enum")
         .documentation("Hello")
@@ -171,16 +160,16 @@ public class EnumElementTest {
         + "  TWO = 2;\n"
         + "  SIX = 6;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldToString() {
+  @Test public void fieldToSchema() {
     EnumConstantElement value = EnumConstantElement.builder().name("NAME").tag(1).build();
     String expected = "NAME = 1;\n";
-    assertThat(value.toString()).isEqualTo(expected);
+    assertThat(value.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldWithDocumentationToString() {
+  @Test public void fieldWithDocumentationToSchema() {
     EnumConstantElement value = EnumConstantElement.builder()
         .name("NAME")
         .tag(1)
@@ -189,21 +178,21 @@ public class EnumElementTest {
     String expected = ""
         + "// Hello\n"
         + "NAME = 1;\n";
-    assertThat(value.toString()).isEqualTo(expected);
+    assertThat(value.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldWithOptions() {
+  @Test public void fieldWithOptionsToSchema() {
     EnumConstantElement value = EnumConstantElement.builder()
         .name("NAME")
         .tag(1)
-        .addOption(OptionElement.create("kit", "kat", true))
-        .addOption(OptionElement.create("tit", "tat"))
+        .addOption(OptionElement.create("kit", STRING, "kat", true))
+        .addOption(OptionElement.create("tit", STRING, "tat"))
         .build();
     String expected = "NAME = 1 [\n"
         + "  (kit) = \"kat\",\n"
         + "  tit = \"tat\"\n"
         + "];\n";
-    assertThat(value.toString()).isEqualTo(expected);
+    assertThat(value.toSchema()).isEqualTo(expected);
   }
 
   @Test public void duplicateValueTagThrows() {
@@ -224,19 +213,10 @@ public class EnumElementTest {
     EnumElement element = EnumElement.builder()
         .name("Enum1")
         .qualifiedName("example.Enum")
-        .addOption(OptionElement.create("allow_alias", true))
+        .addOption(OptionElement.create("allow_alias", BOOLEAN, "true"))
         .addConstant(EnumConstantElement.builder().name("VALUE1").tag(1).build())
         .addConstant(EnumConstantElement.builder().name("VALUE2").tag(1).build())
         .build();
-
-    String expected = ""
-        + "enum Enum1 {\n"
-        + "  option allow_alias = true;\n"
-        + "\n"
-        + "  VALUE1 = 1;\n"
-        + "  VALUE2 = 1;\n"
-        + "}\n";
-
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.constants()).hasSize(2);
   }
 }

--- a/src/test/java/com/squareup/protoparser/ExtendElementTest.java
+++ b/src/test/java/com/squareup/protoparser/ExtendElementTest.java
@@ -64,13 +64,13 @@ public class ExtendElementTest {
     }
   }
 
-  @Test public void emptyToString() {
+  @Test public void emptyToSchema() {
     ExtendElement extend = ExtendElement.builder().name("Name").build();
     String expected = "extend Name {}\n";
-    assertThat(extend.toString()).isEqualTo(expected);
+    assertThat(extend.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void simpleToString() {
+  @Test public void simpleToSchema() {
     ExtendElement extend = ExtendElement.builder()
         .name("Name")
         .addField(FieldElement.builder().label(REQUIRED).type(STRING).name("name").tag(1).build())
@@ -79,7 +79,7 @@ public class ExtendElementTest {
         + "extend Name {\n"
         + "  required string name = 1;\n"
         + "}\n";
-    assertThat(extend.toString()).isEqualTo(expected);
+    assertThat(extend.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleFields() {
@@ -91,15 +91,10 @@ public class ExtendElementTest {
         .name("Name")
         .addFields(Arrays.asList(firstName, lastName))
         .build();
-    String expected = ""
-        + "extend Name {\n"
-        + "  required string first_name = 1;\n"
-        + "  required string last_name = 2;\n"
-        + "}\n";
-    assertThat(extend.toString()).isEqualTo(expected);
+    assertThat(extend.fields()).hasSize(2);
   }
 
-  @Test public void simpleWithDocumentationToString() {
+  @Test public void simpleWithDocumentationToSchema() {
     ExtendElement extend = ExtendElement.builder()
         .name("Name")
         .documentation("Hello")
@@ -115,7 +110,7 @@ public class ExtendElementTest {
         + "extend Name {\n"
         + "  required string name = 1;\n"
         + "}\n";
-    assertThat(extend.toString()).isEqualTo(expected);
+    assertThat(extend.toSchema()).isEqualTo(expected);
   }
 
   @Test public void duplicateTagValueThrows() {

--- a/src/test/java/com/squareup/protoparser/ExtensionsElementTest.java
+++ b/src/test/java/com/squareup/protoparser/ExtensionsElementTest.java
@@ -21,29 +21,29 @@ public class ExtensionsElementTest {
     }
   }
 
-  @Test public void singleValueToString() {
+  @Test public void singleValueToSchema() {
     ExtensionsElement actual = ExtensionsElement.create(500, 500);
     String expected = "extensions 500;\n";
-    assertThat(actual.toString()).isEqualTo(expected);
+    assertThat(actual.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void rangeToString() {
+  @Test public void rangeToSchema() {
     ExtensionsElement actual = ExtensionsElement.create(500, 505);
     String expected = "extensions 500 to 505;\n";
-    assertThat(actual.toString()).isEqualTo(expected);
+    assertThat(actual.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void maxRangeToString() {
+  @Test public void maxRangeToSchema() {
     ExtensionsElement actual = ExtensionsElement.create(500, ProtoFile.MAX_TAG_VALUE);
     String expected = "extensions 500 to max;\n";
-    assertThat(actual.toString()).isEqualTo(expected);
+    assertThat(actual.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void withDocumentationToString() {
+  @Test public void withDocumentationToSchema() {
     ExtensionsElement actual = ExtensionsElement.create(500, 500, "Hello");
     String expected = ""
         + "// Hello\n"
         + "extensions 500;\n";
-    assertThat(actual.toString()).isEqualTo(expected);
+    assertThat(actual.toSchema()).isEqualTo(expected);
   }
 }

--- a/src/test/java/com/squareup/protoparser/FieldElementTest.java
+++ b/src/test/java/com/squareup/protoparser/FieldElementTest.java
@@ -1,6 +1,7 @@
 package com.squareup.protoparser;
 
 import com.squareup.protoparser.DataType.NamedType;
+import com.squareup.protoparser.OptionElement.Kind;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -18,14 +19,14 @@ public final class FieldElementTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("default", EnumConstantElement.anonymous("TEST")))
-        .addOption(OptionElement.create("deprecated", "true"))
+        .addOption(OptionElement.create("default", Kind.ENUM, "TEST"))
+        .addOption(OptionElement.create("deprecated", Kind.BOOLEAN, "true"))
         .build();
     assertThat(field.isDeprecated()).isTrue();
-    assertThat(field.getDefault()).isEqualTo(EnumConstantElement.anonymous("TEST"));
+    assertThat(field.getDefault().value()).isEqualTo("TEST");
     assertThat(field.options()).containsOnly( //
-        OptionElement.create("default", EnumConstantElement.anonymous("TEST")), //
-        OptionElement.create("deprecated", "true"));
+        OptionElement.create("default", Kind.ENUM, "TEST"), //
+        OptionElement.create("deprecated", Kind.BOOLEAN, "true"));
   }
 
   @Test public void deprecatedSupportStringAndBoolean() {
@@ -34,7 +35,7 @@ public final class FieldElementTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", "true"))
+        .addOption(OptionElement.create("deprecated", Kind.STRING, "true"))
         .build();
     assertThat(field1.isDeprecated()).isTrue();
     FieldElement field2 = FieldElement.builder()
@@ -42,7 +43,7 @@ public final class FieldElementTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", true))
+        .addOption(OptionElement.create("deprecated", Kind.BOOLEAN, "true"))
         .build();
     assertThat(field2.isDeprecated()).isTrue();
   }
@@ -53,7 +54,7 @@ public final class FieldElementTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("packed", "true"))
+        .addOption(OptionElement.create("packed", Kind.STRING, "true"))
         .build();
     assertThat(field1.isPacked()).isTrue();
     FieldElement field2 = FieldElement.builder()
@@ -61,14 +62,14 @@ public final class FieldElementTest {
         .type(NamedType.create("CType"))
         .name("ctype")
         .tag(1)
-        .addOption(OptionElement.create("packed", true))
+        .addOption(OptionElement.create("packed", Kind.BOOLEAN, "true"))
         .build();
     assertThat(field2.isPacked()).isTrue();
   }
 
   @Test public void addMultipleOptions() {
-    OptionElement kitKat = OptionElement.create("kit", "kat");
-    OptionElement fooBar = OptionElement.create("foo", "bar");
+    OptionElement kitKat = OptionElement.create("kit", Kind.STRING, "kat");
+    OptionElement fooBar = OptionElement.create("foo", Kind.STRING, "bar");
     FieldElement field = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
@@ -76,12 +77,7 @@ public final class FieldElementTest {
         .tag(1)
         .addOptions(Arrays.asList(kitKat, fooBar))
         .build();
-    String expected = ""
-        + "required string name = 1 [\n"
-        + "  kit = \"kat\"\n"
-        + "  foo = \"bar\"\n"
-        + "];\n";
-    assertThat(field.toString()).isEqualTo(expected);
+    assertThat(field.options()).hasSize(2);
   }
 
   @Test public void labelRequired() {

--- a/src/test/java/com/squareup/protoparser/MessageElementTest.java
+++ b/src/test/java/com/squareup/protoparser/MessageElementTest.java
@@ -1,5 +1,6 @@
 package com.squareup.protoparser;
 
+import com.squareup.protoparser.OptionElement.Kind;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -139,13 +140,13 @@ public class MessageElementTest {
     }
   }
 
-  @Test public void emptyToString() {
+  @Test public void emptyToSchema() {
     TypeElement element = MessageElement.builder().name("Message").build();
     String expected = "message Message {}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void simpleToString() {
+  @Test public void simpleToSchema() {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(FieldElement.builder().label(REQUIRED).type(STRING).name("name").tag(1).build())
@@ -154,7 +155,7 @@ public class MessageElementTest {
         + "message Message {\n"
         + "  required string name = 1;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleFields() {
@@ -162,19 +163,14 @@ public class MessageElementTest {
         FieldElement.builder().label(REQUIRED).type(STRING).name("first_name").tag(1).build();
     FieldElement lastName =
         FieldElement.builder().label(REQUIRED).type(STRING).name("last_name").tag(2).build();
-    TypeElement element = MessageElement.builder()
+    MessageElement element = MessageElement.builder()
         .name("Message")
         .addFields(Arrays.asList(firstName, lastName))
         .build();
-    String expected = ""
-        + "message Message {\n"
-        + "  required string first_name = 1;\n"
-        + "  required string last_name = 2;\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.fields()).hasSize(2);
   }
 
-  @Test public void simpleWithDocumentationToString() {
+  @Test public void simpleWithDocumentationToSchema() {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .documentation("Hello")
@@ -185,10 +181,10 @@ public class MessageElementTest {
         + "message Message {\n"
         + "  required string name = 1;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void simpleWithOptionsToString() {
+  @Test public void simpleWithOptionsToSchema() {
     FieldElement field = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
@@ -198,7 +194,7 @@ public class MessageElementTest {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(field)
-        .addOption(OptionElement.create("kit", "kat"))
+        .addOption(OptionElement.create("kit", Kind.STRING, "kat"))
         .build();
     String expected = ""
         + "message Message {\n"
@@ -206,7 +202,7 @@ public class MessageElementTest {
         + "\n"
         + "  required string name = 1;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleOptions() {
@@ -216,24 +212,17 @@ public class MessageElementTest {
         .name("name")
         .tag(1)
         .build();
-    OptionElement kitKat = OptionElement.create("kit", "kat");
-    OptionElement fooBar = OptionElement.create("foo", "bar");
-    TypeElement element = MessageElement.builder()
+    OptionElement kitKat = OptionElement.create("kit", Kind.STRING, "kat");
+    OptionElement fooBar = OptionElement.create("foo", Kind.STRING, "bar");
+    MessageElement element = MessageElement.builder()
         .name("Message")
         .addField(field)
         .addOptions(Arrays.asList(kitKat, fooBar))
         .build();
-    String expected = ""
-        + "message Message {\n"
-        + "  option kit = \"kat\";\n"
-        + "  option foo = \"bar\";\n"
-        + "\n"
-        + "  required string name = 1;\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.options()).hasSize(2);
   }
 
-  @Test public void simpleWithNestedElementsToString() {
+  @Test public void simpleWithNestedElementsToSchema() {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(FieldElement.builder().label(REQUIRED).type(STRING).name("name").tag(1).build())
@@ -251,7 +240,7 @@ public class MessageElementTest {
         + "    required string name = 1;\n"
         + "  }\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleTypes() {
@@ -267,17 +256,10 @@ public class MessageElementTest {
             .build())
         .addTypes(Arrays.asList(nested1, nested2))
         .build();
-    String expected = ""
-        + "message Message {\n"
-        + "  required string name = 1;\n"
-        + "\n"
-        + "  message Nested1 {}\n"
-        + "  message Nested2 {}\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.nestedElements()).hasSize(2);
   }
 
-  @Test public void simpleWithExtensionsToString() {
+  @Test public void simpleWithExtensionsToSchema() {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(FieldElement.builder()
@@ -294,13 +276,13 @@ public class MessageElementTest {
         + "\n"
         + "  extensions 500 to 501;\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleExtensions() {
     ExtensionsElement fives = ExtensionsElement.create(500, 501);
     ExtensionsElement sixes = ExtensionsElement.create(600, 601);
-    TypeElement element = MessageElement.builder()
+    MessageElement element = MessageElement.builder()
         .name("Message")
         .addField(FieldElement.builder()
             .label(REQUIRED)
@@ -310,17 +292,10 @@ public class MessageElementTest {
             .build())
         .addExtensions(Arrays.asList(fives, sixes))
         .build();
-    String expected = ""
-        + "message Message {\n"
-        + "  required string name = 1;\n"
-        + "\n"
-        + "  extensions 500 to 501;\n"
-        + "  extensions 600 to 601;\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.extensions()).hasSize(2);
   }
 
-  @Test public void oneOfToString() {
+  @Test public void oneOfToSchema() {
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addOneOf(OneOfElement.builder()
@@ -334,7 +309,7 @@ public class MessageElementTest {
         + "    string name = 1;\n"
         + "  }\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleOneOfs() {
@@ -346,23 +321,14 @@ public class MessageElementTest {
         .name("hey")
         .addField(FieldElement.builder().label(ONE_OF).type(STRING).name("city").tag(2).build())
         .build();
-    TypeElement element = MessageElement.builder()
+    MessageElement element = MessageElement.builder()
         .name("Message")
         .addOneOfs(Arrays.asList(hi, hey))
         .build();
-    String expected = ""
-        + "message Message {\n"
-        + "  oneof hi {\n"
-        + "    string name = 1;\n"
-        + "  }\n"
-        + "  oneof hey {\n"
-        + "    string city = 2;\n"
-        + "  }\n"
-        + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.oneOfs()).hasSize(2);
   }
 
-  @Test public void multipleEverythingToString() {
+  @Test public void multipleEverythingToSchema() {
     FieldElement field1 = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
@@ -398,7 +364,7 @@ public class MessageElementTest {
     ExtensionsElement extensions1 = ExtensionsElement.create(500, 501);
     ExtensionsElement extensions2 = ExtensionsElement.create(503, 503);
     TypeElement nested = MessageElement.builder().name("Nested").addField(field1).build();
-    OptionElement option = OptionElement.create("kit", "kat");
+    OptionElement option = OptionElement.create("kit", Kind.STRING, "kat");
     TypeElement element = MessageElement.builder()
         .name("Message")
         .addField(field1)
@@ -431,10 +397,10 @@ public class MessageElementTest {
         + "    required string name = 1;\n"
         + "  }\n"
         + "}\n";
-    assertThat(element.toString()).isEqualTo(expected);
+    assertThat(element.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldToString() {
+  @Test public void fieldToSchema() {
     FieldElement field = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
@@ -442,10 +408,10 @@ public class MessageElementTest {
         .tag(1)
         .build();
     String expected = "required string name = 1;\n";
-    assertThat(field.toString()).isEqualTo(expected);
+    assertThat(field.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void oneOfFieldToString() {
+  @Test public void oneOfFieldToSchema() {
     FieldElement field = FieldElement.builder()
         .label(ONE_OF)
         .type(STRING)
@@ -453,10 +419,10 @@ public class MessageElementTest {
         .tag(1)
         .build();
     String expected = "string name = 1;\n";
-    assertThat(field.toString()).isEqualTo(expected);
+    assertThat(field.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldWithDocumentationToString() {
+  @Test public void fieldWithDocumentationToSchema() {
     FieldElement field = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
@@ -467,21 +433,21 @@ public class MessageElementTest {
     String expected = ""
         + "// Hello\n"
         + "required string name = 1;\n";
-    assertThat(field.toString()).isEqualTo(expected);
+    assertThat(field.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void fieldWithOptions() {
+  @Test public void fieldWithOptionsToSchema() {
     FieldElement field = FieldElement.builder()
         .label(REQUIRED)
         .type(STRING)
         .name("name")
         .tag(1)
-        .addOption(OptionElement.create("kit", "kat"))
+        .addOption(OptionElement.create("kit", Kind.STRING, "kat"))
         .build();
     String expected = "required string name = 1 [\n"
         + "  kit = \"kat\"\n"
         + "];\n";
-    assertThat(field.toString()).isEqualTo(expected);
+    assertThat(field.toSchema()).isEqualTo(expected);
   }
 
   @Test public void duplicateTagValueThrows() {
@@ -588,7 +554,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", "true"))
+        .addOption(OptionElement.create("deprecated", Kind.BOOLEAN, "true"))
         .build();
     assertThat(field.isDeprecated()).isTrue();
   }
@@ -599,7 +565,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("deprecated", "false"))
+        .addOption(OptionElement.create("deprecated", Kind.BOOLEAN, "false"))
         .build();
     assertThat(field.isDeprecated()).isFalse();
   }
@@ -620,7 +586,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("packed", "true"))
+        .addOption(OptionElement.create("packed", Kind.BOOLEAN, "true"))
         .build();
     assertThat(field.isPacked()).isTrue();
   }
@@ -631,7 +597,7 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("packed", "false"))
+        .addOption(OptionElement.create("packed", Kind.BOOLEAN, "false"))
         .build();
     assertThat(field.isPacked()).isFalse();
   }
@@ -652,9 +618,9 @@ public class MessageElementTest {
         .type(STRING)
         .name("name1")
         .tag(1)
-        .addOption(OptionElement.create("default", "foo"))
+        .addOption(OptionElement.create("default", Kind.STRING, "foo"))
         .build();
-    assertThat(field.getDefault()).isEqualTo("foo");
+    assertThat(field.getDefault().value()).isEqualTo("foo");
   }
 
   @Test public void defaultMissing() {

--- a/src/test/java/com/squareup/protoparser/ServiceElementTest.java
+++ b/src/test/java/com/squareup/protoparser/ServiceElementTest.java
@@ -1,6 +1,7 @@
 package com.squareup.protoparser;
 
 import com.squareup.protoparser.DataType.NamedType;
+import com.squareup.protoparser.OptionElement.Kind;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
@@ -81,13 +82,13 @@ public class ServiceElementTest {
     }
   }
 
-  @Test public void emptyToString() {
+  @Test public void emptyToSchema() {
     ServiceElement service = ServiceElement.builder().name("Service").build();
     String expected = "service Service {}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void singleToString() {
+  @Test public void singleToSchema() {
     ServiceElement service = ServiceElement.builder()
         .name("Service")
         .addRpc(RpcElement.builder()
@@ -100,7 +101,7 @@ public class ServiceElementTest {
         + "service Service {\n"
         + "  rpc Name (RequestType) returns (ResponseType);\n"
         + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleRpcs() {
@@ -118,18 +119,13 @@ public class ServiceElementTest {
         .name("Service")
         .addRpcs(Arrays.asList(firstName, lastName))
         .build();
-    String expected = ""
-        + "service Service {\n"
-        + "  rpc FirstName (RequestType) returns (ResponseType);\n"
-        + "  rpc LastName (RequestType) returns (ResponseType);\n"
-        + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.rpcs()).hasSize(2);
   }
 
-  @Test public void singleWithOptionsToString() {
+  @Test public void singleWithOptionsToSchema() {
     ServiceElement service = ServiceElement.builder()
         .name("Service")
-        .addOption(OptionElement.create("foo", "bar"))
+        .addOption(OptionElement.create("foo", Kind.STRING, "bar"))
         .addRpc(RpcElement.builder()
             .name("Name")
             .requestType(NamedType.create("RequestType"))
@@ -142,12 +138,12 @@ public class ServiceElementTest {
         + "\n"
         + "  rpc Name (RequestType) returns (ResponseType);\n"
         + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.toSchema()).isEqualTo(expected);
   }
 
   @Test public void addMultipleOptions() {
-    OptionElement kitKat = OptionElement.create("kit", "kat");
-    OptionElement fooBar = OptionElement.create("foo", "bar");
+    OptionElement kitKat = OptionElement.create("kit", Kind.STRING, "kat");
+    OptionElement fooBar = OptionElement.create("foo", Kind.STRING, "bar");
     ServiceElement service = ServiceElement.builder()
         .name("Service")
         .addOptions(Arrays.asList(kitKat, fooBar))
@@ -157,17 +153,10 @@ public class ServiceElementTest {
             .responseType(NamedType.create("ResponseType"))
             .build())
         .build();
-    String expected = ""
-        + "service Service {\n"
-        + "  option kit = \"kat\";\n"
-        + "  option foo = \"bar\";\n"
-        + "\n"
-        + "  rpc Name (RequestType) returns (ResponseType);\n"
-        + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.options()).hasSize(2);
   }
 
-  @Test public void singleWithDocumentation() {
+  @Test public void singleWithDocumentationToSchema() {
     ServiceElement service = ServiceElement.builder()
         .name("Service")
         .documentation("Hello")
@@ -182,10 +171,10 @@ public class ServiceElementTest {
         + "service Service {\n"
         + "  rpc Name (RequestType) returns (ResponseType);\n"
         + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void multipleToString() {
+  @Test public void multipleToSchema() {
     RpcElement rpc = RpcElement.builder()
         .name("Name")
         .requestType(NamedType.create("RequestType"))
@@ -198,20 +187,20 @@ public class ServiceElementTest {
         + "  rpc Name (RequestType) returns (ResponseType);\n"
         + "  rpc Name (RequestType) returns (ResponseType);\n"
         + "}\n";
-    assertThat(service.toString()).isEqualTo(expected);
+    assertThat(service.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void rpcToString() {
+  @Test public void rpcToSchema() {
     RpcElement rpc = RpcElement.builder()
         .name("Name")
         .requestType(NamedType.create("RequestType"))
         .responseType(NamedType.create("ResponseType"))
         .build();
     String expected = "rpc Name (RequestType) returns (ResponseType);\n";
-    assertThat(rpc.toString()).isEqualTo(expected);
+    assertThat(rpc.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void rpcWithDocumentationToString() {
+  @Test public void rpcWithDocumentationToSchema() {
     RpcElement rpc = RpcElement.builder()
         .name("Name")
         .documentation("Hello")
@@ -221,20 +210,20 @@ public class ServiceElementTest {
     String expected = ""
         + "// Hello\n"
         + "rpc Name (RequestType) returns (ResponseType);\n";
-    assertThat(rpc.toString()).isEqualTo(expected);
+    assertThat(rpc.toSchema()).isEqualTo(expected);
   }
 
-  @Test public void rpcWithOptions() {
+  @Test public void rpcWithOptionsToSchema() {
     RpcElement rpc = RpcElement.builder()
         .name("Name")
         .requestType(NamedType.create("RequestType"))
         .responseType(NamedType.create("ResponseType"))
-        .addOption(OptionElement.create("foo", "bar"))
+        .addOption(OptionElement.create("foo", Kind.STRING, "bar"))
         .build();
     String expected = ""
         + "rpc Name (RequestType) returns (ResponseType) {\n"
         + "  option foo = \"bar\";\n"
         + "};\n";
-    assertThat(rpc.toString()).isEqualTo(expected);
+    assertThat(rpc.toSchema()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
This also changes rendering the schema from implicitly being behind `toString()` to an explicit `toSchema()`.